### PR TITLE
Initialize image attribute for MainFunc

### DIFF
--- a/GUI/main.py
+++ b/GUI/main.py
@@ -95,6 +95,7 @@ class MainFunc(QMainWindow):
 
         self.image_files = None
         self.img_path = None
+        self.image = None
         self.save_path = None
         self.clicked_event = False
         self.paint_event = False
@@ -389,8 +390,9 @@ class MainFunc(QMainWindow):
         self.ui.label_3.setPixmap(pixmap)
 
     def show_qt(self):
-        if self.image is not None:
-            self._set_label_pixmap_from_array(self.image)
+        image = getattr(self, "image", None)
+        if image is not None:
+            self._set_label_pixmap_from_array(image)
 
     def next_img(self):
         if self.img_path and not self.clicked_event and not self.paint_event:


### PR DESCRIPTION
## Summary
- define `self.image` during MainFunc initialization so the attribute is always available
- guard `show_qt` by pulling the image via `getattr` before attempting to update the pixmap

## Testing
- ⚠️ `QT_QPA_PLATFORM=offscreen python - <<'PY'
from PyQt5.QtWidgets import QApplication
from GUI.main import MainFunc

app = QApplication([])
window = MainFunc()
window.show_qt()
print("show_qt executed without error")
PY` *(fails: ImportError: libGL.so.1: cannot open shared object file: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68d9facce9d083299315d596967b3927